### PR TITLE
Add mastodon link verification

### DIFF
--- a/flarum/extend.php
+++ b/flarum/extend.php
@@ -26,6 +26,7 @@ return [
 <link rel="mask-icon" href="/780febcc.mask-icon.svg" color="#1a1a1a"/>
 <link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link rel="manifest" href="/manifest.webmanifest"/>
+<link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
             ';
         })
 ];


### PR DESCRIPTION
Add rel=me link verification for GrapheneOS mastodon bio. 
The verification process is triggered when admin saves profile after this is merged. 
Additionally, this will trigger the GitHub rel=me for the Mastodon profile in GitHub that's already in place.