### PR TITLE
flarum-deploy: fix find precedence to delete both .gz and .br

### DIFF
--- a/flarum-deploy
+++ b/flarum-deploy
@@ -3,7 +3,7 @@
 shopt -s extglob nullglob
 
 cd /opt
-find flarum/public/assets/ -name '*.gz' -o -name '*.br' -delete
+find flarum/public/assets/ \( -name '*.gz' -o -name '*.br' \) -delete
 su flarum-admin -c "rsync -tv --fsync --preallocate flarum-staging/composer.{lock,json} flarum/"
 systemctl stop php-fpm
 su flarum-admin -c "rsync -tvr --delete --fsync --preallocate flarum-staging/vendor/ flarum/vendor"


### PR DESCRIPTION
Without parentheses, `find` parses `-name '*.gz' -o -name '*.br' -delete` as `-name '*.gz' -o ( -name '*.br' -a -delete )`, so only `.br` files are deleted and stale `.gz` files remain.

Repro:
```
$ touch a.gz b.br
$ find . -name '*.gz' -o -name '*.br' -delete
$ ls
a.gz
```

Fix matches the form already used in flarum-asset-compress. Mostly self-healing because flarum-asset-compress runs at the end of deploy and clears both, but stale `.gz` files persist if deploy aborts in between.